### PR TITLE
Add TEMPLOT5_OUTPUT to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ logs/
 # Application bundle for Mac OS
 *.app/
 
-# Application output folders
-TEMPLOT5_OUTPUT/
+# Generated exe
+templot_5.exe
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ logs/
 # Application bundle for Mac OS
 *.app/
 
+# Application output folders
+TEMPLOT5_OUTPUT/
+
+


### PR DESCRIPTION
This tells git to ignore any files that are created in the TEMPLOT5_OUTPUT folder.

Existing files in this folder that are in git will continue to be tracked, and will be shown if they are changed.

If you need to add a file in the folder to git you can still do this by manually staging the file from the command line.