### PR TITLE
Change marks_list to dynamic array

### DIFF
--- a/enter_timber.pas
+++ b/enter_timber.pas
@@ -143,9 +143,9 @@ begin
 
       // check entered number string is in control template marks list...
 
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
+  if Length(marks_list)=0 then EXIT;        // marks list not valid.
 
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -153,7 +153,7 @@ begin
 
   for i:=0 to (mark_index-1) do begin     // (mark_index is always the next free slot)
     try
-      ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
+      ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
       if ptr_1st=nil then EXIT;
 
       code:=ptr_1st^.code;

--- a/export_draw_unit.pas
+++ b/export_draw_unit.pas
@@ -447,7 +447,6 @@ var
                   for i:=0 to (mark_index-1) do begin   // (mark_index is always the next free slot)
 
                     ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
-                    if ptr_1st=nil then BREAK;
 
                     mark_code:=ptr_1st^.code;              // check this mark wanted.
 
@@ -523,34 +522,32 @@ var
 		                     (mark_code=493) or (mark_code=494) or (mark_code=497))		                             // chair outlines
                        then begin
                               ptr_2nd:=@marks_list[i+1];        // pointer to the second infill Tmark record.
-                              if ptr_2nd=nil then BREAK;
 
                               p1:=ptr_1st^.p1;              // x1,y1 in  1/100ths mm
                               p2:=ptr_1st^.p2;              // x2,y2 in  1/100ths mm
                               p3:=ptr_2nd^.p1;              // x3,y3 in  1/100ths mm
                               p4:=ptr_2nd^.p2;              // x4,y4 in  1/100ths mm
-							  
-							                       // SC 20-SEP-2024 556
-							                       // chair outline extra marks
+
+                                     // SC 20-SEP-2024 556
+                                     // chair outline extra marks
                               if (mark_code=484) or (mark_code=485) or (mark_code=493) or (mark_code=494) or (mark_code=497)    // another 12 marks for radiused corners
                                  then begin
-                                   					n:=0;
-                                   					nn:=2;
+                                        n:=0;
+                                        nn:=2;
 
-                                   					repeat
+                                        repeat
                                           ptr_3rd:=@marks_list[i+nn];        // pointer to the next infill Tmark record.
-                                   					  if ptr_3rd=nil then EXIT;
 
-                                   					  p[n]:=ptr_3rd^.p1;       // 1/100ths mm
-                                   					  p[n+1]:=ptr_3rd^.p2;     // 1/100ths mm
+                                          p[n]:=ptr_3rd^.p1;       // 1/100ths mm
+                                          p[n+1]:=ptr_3rd^.p2;     // 1/100ths mm
 
-                                    					  INC(n);   //+2
-                                   					  INC(n);
-                                   					  INC(nn);  //+1
+                                          INC(n);   //+2
+                                          INC(n);
+                                          INC(nn);  //+1
                                         until n>26;     // was 22
-				                                  end;
-                       					  // sc 20-sep-2024 556
-							  
+                                      end;
+                                  // sc 20-sep-2024 556
+
                             end
                        else ptr_2nd:=nil;    // keep compiler happy.
 

--- a/export_draw_unit.pas
+++ b/export_draw_unit.pas
@@ -436,7 +436,7 @@ var
                 // sc 20-sep-2024
 
               begin
-                markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+                markmax:=High(marks_list);  // max index for the present list.
 
                 if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -446,7 +446,7 @@ var
 
                   for i:=0 to (mark_index-1) do begin   // (mark_index is always the next free slot)
 
-                    ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
+                    ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
                     if ptr_1st=nil then BREAK;
 
                     mark_code:=ptr_1st^.code;              // check this mark wanted.
@@ -522,7 +522,7 @@ var
 		                     (mark_code=484) or (mark_code=485) or (mark_code=487) or		                           // chair outlines
 		                     (mark_code=493) or (mark_code=494) or (mark_code=497))		                             // chair outlines
                        then begin
-                              ptr_2nd:=Pointer(intarray_get(marks_list_ptr,i+1));        // pointer to the second infill Tmark record.
+                              ptr_2nd:=@marks_list[i+1];        // pointer to the second infill Tmark record.
                               if ptr_2nd=nil then BREAK;
 
                               p1:=ptr_1st^.p1;              // x1,y1 in  1/100ths mm
@@ -538,7 +538,7 @@ var
                                    					nn:=2;
 
                                    					repeat
-                                          ptr_3rd:=Pointer(intarray_get(marks_list_ptr,i+nn));        // pointer to the next infill Tmark record.
+                                          ptr_3rd:=@marks_list[i+nn];        // pointer to the next infill Tmark record.
                                    					  if ptr_3rd=nil then EXIT;
 
                                    					  p[n]:=ptr_3rd^.p1;       // 1/100ths mm
@@ -1640,7 +1640,7 @@ begin
 
 
 
-                    if marks_list_ptr=nil then EXIT; //BREAK;       // pointer to marks list not valid, exit all sheets.
+                    if Length(marks_list)=0 then EXIT; //BREAK;       // pointer to marks list not valid, exit all sheets.
 
                     draw_marks(grid_left,grid_top,False);   // print all the background timbering and marks except rail joints.
 

--- a/keep_select.pas
+++ b/keep_select.pas
@@ -7055,14 +7055,14 @@ begin
 
                               //  now draw turnout timbers and all marks (except rail ends) ...
 
-          if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
-          markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+          if Length(marks_list)=0 then EXIT;        // pointer to marks list not valid.
+          markmax:=High(marks_list);  // max index for the present list.
 
           if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
           for i:=0 to (mark_index-1) do begin   // (mark_index is always the next free slot)
 
-            ptr:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
+            ptr:=@marks_list[i];  // pointer to the next Tmark record.
             if ptr=nil then EXIT;
 
             code:=ptr^.code;             // check this mark wanted.
@@ -8400,8 +8400,8 @@ begin
 
                        // copy mark data from list (not rail ends) ...
 
-                    if marks_list_ptr=nil then EXIT;                 // pointer to marks list not valid.
-                    markmax:=intarray_max(marks_list_ptr);           // max index for the present list.
+                    if Length(marks_list)=0 then EXIT;                 // pointer to marks list not valid.
+                    markmax:=High(marks_list);           // max index for the present list.
                     if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
                     for i:=0 to 7 do begin                           // 235b 7 was 4
@@ -8412,7 +8412,7 @@ begin
                     end;//for
 
                     for i:=0 to (mark_index-1) do begin              // (mark_index is always the next free slot)
-                      ptr:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
+                      ptr:=@marks_list[i];  // pointer to the next Tmark record.
                       if ptr=nil then EXIT;
 
                       intarray_set(list_bgnd_marks[0],i,ptr^.p1.X);

--- a/math_unit.pas
+++ b/math_unit.pas
@@ -6503,7 +6503,7 @@ begin
 end;
 //______________________________________________________________________________
 
-function new_marks_list(var list_p:Pointer):boolean;
+function new_marks_list(var list: Tmark_array):boolean;
 
          // return pointer to array of pointers to Tmark records.
 var
@@ -6518,25 +6518,9 @@ var
 begin
   RESULT:=True;                                 // assume good result.
 
-  if list_p<>nil
-     then begin                                 // first free any previous memory.
-            array_max:=intarray_max(list_p);
-            for n:=0 to array_max do begin
-              p:=Pointer(intarray_get(list_p,n));
-              if p<>nil
-                 then begin
-                        try
-                          Dispose(p);
-                        except
-                          RESULT:=False;
-                          EXIT;
-                        end;//try
-                      end;
-            end;//for
-            intarray_free(list_p);
-          end;
+  SetLength(list, 0);
 
-                // estimate number of marks needed...
+  // estimate number of marks needed...
 
   mark_count:=0;
 
@@ -6635,22 +6619,9 @@ begin
 
   mark_count:=mark_count+500;     // 221a  500 more for luck
 
-  list_p:=intarray_create(mark_count,False);    // array of pointers to Tmark records.
-  if list_p<>nil
-     then begin
-            for n:=0 to mark_count do begin
-              try
-                New(p);
-              except
-                RESULT:=False;
-                p:=nil;
-              end;//try
+  SetLength(list, mark_count);
 
-              intarray_set(list_p,n,Integer(p));  // put pointer to each mark (or nil) in array.
-            end;//for
-          end
-     else RESULT:=False;
-
+  Result := True;
 end;
 //___________________________________________________________________________________________
 
@@ -6806,7 +6777,7 @@ begin
   mark_index:=0;               //  init index for list of new marks.
   timb_numbers_str:='';        //  and accumulator string for the timber numbers.
 
-  if new_marks_list(marks_list_ptr)=False    // ### clear the old marks list and create a new one.
+  if new_marks_list(marks_list)=False    // ### clear the old marks list and create a new one.
      then begin
             memory_alert;     //  warn him.
             EXIT;
@@ -20462,14 +20433,12 @@ var
 
 begin
 
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  if Length(marks_list) = 0 then EXIT;        // pointer to marks list not valid.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;
 
-  ptr:=Pointer(intarray_get(marks_list_ptr,mark_index));  // pointer to the next Tmark record.
-
-  if ptr=nil then EXIT;
+  ptr:=@marks_list[mark_index];  // pointer to the next Tmark record.
 
   ptr^.code:=code;                     // code for this entry :
 
@@ -22139,8 +22108,8 @@ begin
     pad_timber_numbers:=current_timber_numbers_menu_entry.Checked;
   end;//with
 
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  if Length(marks_list) = 0 then EXIT;        // pointer to marks list not valid.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -22151,7 +22120,7 @@ begin
     for i:=0 to (mark_index-1) do begin   // (mark_index is always the next free slot)
 
       try
-        ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
+        ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
         if ptr_1st=nil then EXIT;
 
 	code:=ptr_1st^.code;
@@ -22164,8 +22133,7 @@ begin
 
         if ((code=203) or (code=233) or (code=293) or (code=484) or (code=485) or (code=487) or (code=493) or (code=494) or (code=497)) and (i<(mark_index-1))      // timber infill, chair outlines
            then begin
-                  ptr_2nd:=Pointer(intarray_get(marks_list_ptr,i+1));        // pointer to the second infill Tmark record.
-                  if ptr_2nd=nil then EXIT;
+                  ptr_2nd:=@marks_list[i+1];        // pointer to the second infill Tmark record.
 
                   p3:=ptr_2nd^.p1;              // x3,y3 in  1/100ths mm
                   p4:=ptr_2nd^.p2;              // x4,y4 in  1/100ths mm
@@ -22179,8 +22147,7 @@ begin
                   nn:=2;
 
                   repeat
-                    ptr_nn:=Pointer(intarray_get(marks_list_ptr,i+nn));        // pointer to the next infill Tmark record.
-                    if ptr_nn=nil then EXIT;
+                    ptr_nn:=@marks_list[i+nn];        // pointer to the next infill Tmark record.
 
                     p[n]:=ptr_nn^.p1;       // 1/100ths mm
                     p[n+1]:=ptr_nn^.p2;     // 1/100ths mm
@@ -37982,9 +37949,9 @@ begin
 
       // find number string clicked on in control template marks list...
 
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
+  if Length(marks_list)=0 then EXIT;        // pointer to marks list not valid.
 
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -37992,8 +37959,7 @@ begin
 
   for i:=0 to (mark_index-1) do begin     // (mark_index is always the next free slot)
     try
-      ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
-      if ptr_1st=nil then EXIT;
+      ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
 
       code:=ptr_1st^.code;
 
@@ -38078,9 +38044,9 @@ begin
   end;//with
 
 
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
+  if Length(marks_list)=0 then EXIT;        // pointer to marks list not valid.
 
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -38088,8 +38054,7 @@ begin
 
   for i:=0 to (mark_index-1) do begin     // (mark_index is always the next free slot)
     try
-      ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
-      if ptr_1st=nil then EXIT;
+      ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
 
       code:=ptr_1st^.code;
 
@@ -38209,16 +38174,15 @@ begin
 
       // find label string clicked on...
 
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
+  if Length(marks_list)=0 then EXIT;        // pointer to marks list not valid.
 
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
   for i:=0 to (mark_index-1) do begin     // (mark_index is always the next free slot)
     try
-      ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
-      if ptr_1st=nil then EXIT;
+      ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
 
       code:=ptr_1st^.code;
 
@@ -38383,16 +38347,15 @@ begin
 
       // find number string clicked on in control template marks list...
 
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
+  if Length(marks_list)=0 then EXIT;        // pointer to marks list not valid.
 
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
   for i:=0 to (mark_index-1) do begin     // (mark_index is always the next free slot)
     try
-      ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
-      if ptr_1st=nil then EXIT;
+      ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
 
       code:=ptr_1st^.code;
 
@@ -38455,9 +38418,9 @@ begin
     half_height:=TextHeight('A') div 2;
   end;//with
 
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
+  if Length(marks_list)=0 then EXIT;        // pointer to marks list not valid.
 
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -38465,8 +38428,7 @@ begin
 
   for i:=0 to (mark_index-1) do begin     // (mark_index is always the next free slot)
     try
-      ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
-      if ptr_1st=nil then EXIT;
+      ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
 
       code:=ptr_1st^.code;
 
@@ -38611,16 +38573,15 @@ begin   // find if on chair label...
 
   mouse_is_over_chair_label_mark:=-1;   // init
 
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
+  if Length(marks_list)=0 then EXIT;        // pointer to marks list not valid.
 
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
   for i:=0 to (mark_index-1) do begin     // (mark_index is always the next free slot)
 
-    ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
-    if ptr_1st=nil then EXIT;
+    ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
 
     code:=ptr_1st^.code;
 

--- a/pad_unit.pas
+++ b/pad_unit.pas
@@ -3819,6 +3819,7 @@ type
           dxf_chair_code:integer;   // [6]   237a  chairing data for 3D exports
           mark_bits:integer;        // [7]   555a  32 bit settings
         end;
+  Tmark_array=array of Tmark;
 
   Tpex=record                      // x,y point floats (TPoint is integer).
          x:extended;
@@ -4460,7 +4461,7 @@ var
   dv_copies:array[0..dv_copies_c] of Tdummy_vehicle_corners;  // up to 32 copies 0.98.a
   dv_copies_index:integer=-1;                                 // init num copies -1
 
-  marks_list_ptr:Pointer=nil;     //###  // pointer to list of pointers to Tmarks.
+  marks_list:Tmark_array;
 
   timb_numbers_str:string='';     // accumulated timber numbering strings with $1B separators.
 

--- a/pdf_laz_unit.pas
+++ b/pdf_laz_unit.pas
@@ -927,7 +927,7 @@ var
               begin
 
 
-                markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+                markmax:=High(marks_list);  // max index for the present list.
 
                 if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -939,7 +939,7 @@ var
 
                   for i:=0 to (mark_index-1) do begin   // (mark_index is always the next free slot)
 
-                    ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
+                    ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
                     if ptr_1st=nil then BREAK;
 
                     mark_code:=ptr_1st^.code;              // check this mark wanted.
@@ -1021,7 +1021,7 @@ var
                     // include chair outline codes
                     if ((mark_code=203) or (mark_code=233) or (mark_code=293) or (mark_code=484) or (mark_code=485) or (mark_code=487) or (mark_code=493) or (mark_code=494) or (mark_code=497)) and (i<(mark_index-1))      // timber infill, chair outlines
                        then begin
-                              ptr_2nd:=Pointer(intarray_get(marks_list_ptr,i+1));        // pointer to the second infill Tmark record.
+                              ptr_2nd:=@marks_list[i+1];        // pointer to the second infill Tmark record.
                               if ptr_2nd=nil then BREAK;
 
                               p1:=ptr_1st^.p1;              // x1,y1 in  1/100ths mm
@@ -1039,7 +1039,7 @@ var
 	                             nn:=2;
 
 	                             repeat
-                                ptr_3rd:=Pointer(intarray_get(marks_list_ptr,i+nn));        // pointer to the next infill Tmark record.
+                                ptr_3rd:=@marks_list[i+nn];        // pointer to the next infill Tmark record.
 	                               if ptr_3rd=nil then EXIT;
 
 			                             p[n]:=ptr_3rd^.p1;       // 1/100ths mm
@@ -2581,7 +2581,7 @@ try
                      // 0.93.a if printing background templates in Quick mode, the control template has been put on the background
 
                  then begin
-                        if marks_list_ptr=nil then BREAK;       // pointer to marks list not valid, exit all sheets.
+                        if Length(marks_list)=0 then BREAK;       // pointer to marks list not valid, exit all sheets.
 
                         draw_marks(grid_left,grid_top,False,False);   // print all the background timbering and marks except rail joints and timber numbers.
 

--- a/print_unit.pas
+++ b/print_unit.pas
@@ -915,7 +915,7 @@ var
                 // sc 16-sep-2024 556
 
               begin
-                markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+                markmax:=High(marks_list);  // max index for the present list.
 
                 if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -925,7 +925,7 @@ var
 
                   for i:=0 to (mark_index-1) do begin   // (mark_index is always the next free slot)
 
-                    ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
+                    ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
                     if ptr_1st=nil then BREAK;
 
                     mark_code:=ptr_1st^.code;              // check this mark wanted.
@@ -1009,7 +1009,7 @@ var
                     //if ((mark_code=203) or (mark_code=233) or (mark_code=293)) and (i<(mark_index-1))      // timber infill
                     if ((mark_code=203) or (mark_code=233) or (mark_code=293) or (mark_code=484) or (mark_code=485) or (mark_code=487) or (mark_code=493) or (mark_code=494) or (mark_code=497)) and (i<(mark_index-1))      // timber infill, chair outlines
                        then begin
-                              ptr_2nd:=Pointer(intarray_get(marks_list_ptr,i+1));        // pointer to the second infill Tmark record.
+                              ptr_2nd:=@marks_list[i+1];        // pointer to the second infill Tmark record.
                               if ptr_2nd=nil then BREAK;
 
                               p1:=ptr_1st^.p1;              // x1,y1 in  1/100ths mm
@@ -1027,7 +1027,7 @@ var
    	                           nn:=2;
 
    	                           repeat
-                                 ptr_3rd:=Pointer(intarray_get(marks_list_ptr,i+nn));        // pointer to the next infill Tmark record.
+                                 ptr_3rd:=@marks_list[i+nn];        // pointer to the next infill Tmark record.
    	                             if ptr_3rd=nil then EXIT;
 
    			                           p[n]:=ptr_3rd^.p1;       // 1/100ths mm
@@ -2688,7 +2688,7 @@ try
 
                then begin
 
-                      if marks_list_ptr=nil then BREAK;       // pointer to marks list not valid, exit all sheets.
+                      if Length(marks_list)=0 then BREAK;       // pointer to marks list not valid, exit all sheets.
 
                       draw_marks(grid_left,grid_top,False,False);   // print all the background timbering and marks except rail joints and timber numbers.
 

--- a/shove_timber.pas
+++ b/shove_timber.pas
@@ -2123,9 +2123,9 @@ var
   num_str,tbnum_str:string;
 
 begin
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
+  if Length(marks_list)=0 then EXIT;        // pointer to marks list not valid.
 
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -2136,7 +2136,7 @@ begin
 
   for i:=0 to (mark_index-1) do begin     // (mark_index is always the next free slot)
     try
-      ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
+      ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
       if ptr_1st=nil then EXIT;
 
       code:=ptr_1st^.code;
@@ -2184,7 +2184,7 @@ var
   num_str,tbnum_str:string;
 
 begin
-  if marks_list_ptr=nil then EXIT;        // pointer to marks list not valid.
+  if Length(marks_list)=0 then EXIT;        // pointer to marks list not valid.
 
   if omit_all_msg_pref=False
      then begin
@@ -2209,7 +2209,7 @@ begin
             if i=5 then EXIT;
           end;
 
-  markmax:=intarray_max(marks_list_ptr);  // max index for the present list.
+  markmax:=High(marks_list);  // max index for the present list.
 
   if mark_index>markmax then mark_index:=markmax;  // ??? shouldn't be.
 
@@ -2220,7 +2220,7 @@ begin
 
   for i:=0 to (mark_index-1) do begin     // (mark_index is always the next free slot)
     try
-      ptr_1st:=Pointer(intarray_get(marks_list_ptr,i));  // pointer to the next Tmark record.
+      ptr_1st:=@marks_list[i];  // pointer to the next Tmark record.
       if ptr_1st=nil then EXIT;
 
       code:=ptr_1st^.code;


### PR DESCRIPTION
Change the marks_list to a dynamic array of Tmark records.
This eliminates Poiinter <-> Integer typecasts that were broken
(mixing 64-bit pointer with 32-bit integer).

Also fixed some TAB formatting